### PR TITLE
Fix: duplicate point closest point to

### DIFF
--- a/polygon.js
+++ b/polygon.js
@@ -203,6 +203,12 @@ Polygon.prototype = {
 
       var a = this.point(i-1);
       var b = this.point(i);
+
+      // handle closed loops
+      if (a.equal(b)) {
+        continue;
+      }
+
       var ab = b.subtract(a, true);
       var veca = vec.subtract(a, true);
       var vecadot = veca.dot(ab);

--- a/test/test.js
+++ b/test/test.js
@@ -1150,3 +1150,21 @@ test('Polygon#intersect', function(t){
 
   t.end();
 })
+
+
+test('issue 6 (NaN)', function(t) {
+  var point = Vec2(10, 10);
+  var pol = Polygon([
+    [1,1],
+    [5,1],
+    [5,5],
+    [1,5],
+    [1,1]
+  ]);
+  var r = pol.closestPointTo(point);
+
+  t.equal(r.x, 5, 'x matches');
+  t.equal(r.y, 5, 'y matches');
+
+  t.end();
+})


### PR DESCRIPTION
When computing `Polygon#closestPointTo` if duplicate points are used, the result is a throw from `vec2` because a NaN is created and used. This patchset fixes that behavior by ensuring that the two points being compared are not equivalent component wise.

closes #6